### PR TITLE
Allow Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "require": {
         "php": ">=8.1.10",
         "eckinox/php-puppeteer": "^1.0",
-        "symfony/http-foundation": "^5.4|^6.0",
-        "symfony/http-kernel": "^5.4|^6.0",
-        "symfony/string": "^5.4|^6.0",
+        "symfony/http-foundation": "^5.4|^6.0|^7.0",
+        "symfony/http-kernel": "^5.4|^6.0|^7.0",
+        "symfony/string": "^5.4|^6.0|^7.0",
         "twig/twig": "^3.8"
     },
     "require-dev": {


### PR DESCRIPTION
Due to the limitations in composer.json, it is. currently not possible to use this bundle with symfony7. With this change it allows it to be installed with symfony7. I have been running this on a few of my projects for a while now.